### PR TITLE
fix: don't throw in the timeslider (undefined etherpadHooks namespace)

### DIFF
--- a/static/js/performance.js
+++ b/static/js/performance.js
@@ -5,22 +5,29 @@
 // was false, it was only when minify was set to true that I needed to do this hack.
 // CRITICAL TODO: This causes a global leak which causes the tests to fail.
 
+// Lazily get (and create) the shared namespace. `documentReady` only fires on the
+// pad page (pad.html), never in the timeslider bootstrap, so hooks that also fire in
+// the timeslider (postToolbarInit, postTimesliderInit) used to throw
+// `TypeError: Cannot set properties of undefined` there. Those uncaught errors
+// surfaced as error toasts and broke core's timeslider specs. Ensuring the namespace
+// exists makes every hook safe regardless of which page fired it.
+const hooks = () => (window.top.etherpadHooks = window.top.etherpadHooks || {});
+
 exports.documentReady = () => {
-  window.top.etherpadHooks = {};
-  window.top.etherpadHooks.documentReady = Date.now();
+  hooks().documentReady = Date.now();
 };
-exports.aceAttribClasses = () => window.top.etherpadHooks.aceAttribClasses = Date.now();
-exports.aceEditorCSS = () => window.top.etherpadHooks.aceEditorCSS = Date.now();
+exports.aceAttribClasses = () => hooks().aceAttribClasses = Date.now();
+exports.aceEditorCSS = () => hooks().aceEditorCSS = Date.now();
 exports.aceInitInnerdocbodyHead =
-    () => window.top.etherpadHooks.aceInitInnerdocbodyHead = Date.now();
-exports.aceInitialized = () => window.top.etherpadHooks.aceInitialized = Date.now();
-exports.postToolbarInit = () => window.top.etherpadHooks.postToolbarInit = Date.now();
-exports.postTimesliderInit = () => window.top.etherpadHooks.postTimesliderInit = Date.now();
+    () => hooks().aceInitInnerdocbodyHead = Date.now();
+exports.aceInitialized = () => hooks().aceInitialized = Date.now();
+exports.postToolbarInit = () => hooks().postToolbarInit = Date.now();
+exports.postTimesliderInit = () => hooks().postTimesliderInit = Date.now();
 
 exports.postAceInit = () => {
-  window.top.etherpadHooks.postAceInit = Date.now();
+  hooks().postAceInit = Date.now();
   const perf = {};
-  perf.etherpadHooks = window.top.etherpadHooks;
+  perf.etherpadHooks = hooks();
   perf.etherpadHooksDuration = {};
 
   // Takes previous hook times and stores a duration


### PR DESCRIPTION
## Why CI is red

The frontend job fails on a **core** spec — `timeslider_identity_changeset.spec.ts` (regression test for ether/etherpad-lite#5214) — not on a plugin spec. This plugin's CI checks out Etherpad core fresh and runs core's whole `frontend-new` suite *with the plugin loaded*, so a new core test can break this repo with no plugin change:

```
Expected: 0
Received: 2
> 100 | expect(await errors.count()).toBe(0);   // .gritter-item.error toasts
```

## Root cause

The perf hooks record timings on a shared namespace:

```js
exports.postTimesliderInit = () => window.top.etherpadHooks.postTimesliderInit = Date.now();
```

`window.top.etherpadHooks` is only created by the `documentReady` hook — and `documentReady` fires **only on the pad page** (`pad.html` / `padBootstrap.js`), never in the timeslider bootstrap. The two hooks that *also* fire in the timeslider — `postToolbarInit` (via `padeditbar.init()`) and `postTimesliderInit` (via `timeSlider.init()`) — therefore dereference an `undefined` namespace and throw:

```
TypeError: Cannot set properties of undefined (setting 'postToolbarInit')
TypeError: Cannot set properties of undefined (setting 'postTimesliderInit')
```

Core's global exception handler (`pad_utils.ts`) turns each uncaught error into a sticky `.gritter-item.error` toast → **2 toasts → `Received: 2`**. This has been latent since the hook namespace was introduced; #5214 is simply the first timeslider spec to assert zero error toasts while plugins are loaded.

## Fix

Initialise the namespace lazily via a `hooks()` helper so every hook is safe regardless of which page fired it. No behavioural change on the pad page (where `documentReady` still runs first).

## Verification

Reproduced the failure mode against both versions by firing the timeslider's two hooks with no `documentReady` (timeslider context):

| version | error toasts that would appear |
|---|---|
| current `main` | **2** — exact messages match CI's `Received: 2` |
| this PR | **0** — namespace populated correctly |

The authoritative integration check is this repo's CI re-running the core timeslider spec against the patched plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)